### PR TITLE
Remove TestEZ from dependency

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -7,8 +7,5 @@ authors = ["Valts Liepiņš <cipharius@pm.me>"]
 realm = "shared"
 registry = "https://github.com/UpliftGames/wally-index"
 
-[dependencies]
-TestEZ = "roblox/testez@0.4.1" # NOTE Dev dependency
-
 [dev-dependencies]
 TestEZ = "roblox/testez@0.4.1"


### PR DESCRIPTION
TestEZ is currently depended upon as both a dev-dependency and a dependency, which causes Wally to fail to install this package with the error:
> A dev dependency cannot be dependened upon by a non-dev dependency

I think the only reason it was done this way was because this was written before wally had proper support for dev-dependencies. Now that it does, this older toml is broken.