### PR TITLE
Replace computeLength with inflate

### DIFF
--- a/src/msgpack.lua
+++ b/src/msgpack.lua
@@ -347,7 +347,7 @@ local function parse(message: buffer, offset: number): (any, number)
   error("Not all decoder cases are handled, report as bug to msgpack-luau maintainer")
 end
 
-local function inflate(result: buffer, minSize: number, oldSize: number)
+local function inflateInternal(result: buffer, minSize: number, oldSize: number)
   if oldSize == 0 then
     return bufferCreate(minSize), minSize
   end
@@ -359,6 +359,14 @@ local function inflate(result: buffer, minSize: number, oldSize: number)
   local temp = bufferCreate(oldSize)
   bufferCopy(temp, 0, result)
   return temp, oldSize
+end
+
+local function inflate(result: buffer, minSize: number, oldSize: number)
+  if minSize > oldSize then
+    local newResult, newSize = inflateInternal(result, minSize, oldSize)
+    return newResult, newSize
+  end
+  return result, oldSize
 end
 
 local extensionTypeLUT = {
@@ -379,23 +387,17 @@ local function encode(
 
   local dtype = type(data)
   if data == nil then
-    if offset + 1 > size then
-      result, size = inflate(result, offset + 1, size)
-    end
+    result, size = inflate(result, offset + 1, size)
 
     writestring(result, offset, "\xC0")
     return result, offset + 1, size
   elseif data == false then
-    if offset + 1 > size then
-      result, size = inflate(result, offset + 1, size)
-    end
+    result, size = inflate(result, offset + 1, size)
 
     writestring(result, offset, "\xC2")
     return result, offset + 1, size
   elseif data == true then
-    if offset + 1 > size then
-      result, size = inflate(result, offset + 1, size)
-    end
+    result, size = inflate(result, offset + 1, size)
 
     writestring(result, offset, "\xC3")
     return result, offset + 1, size
@@ -403,35 +405,27 @@ local function encode(
     local length = #data
 
     if length <= 31 then
-      if offset + 1 + length > size then
-        result, size = inflate(result, offset + 1 + length, size)
-      end
+      result, size = inflate(result, offset + 1 + length, size)
 
       writeu8(result, offset, bor(0xA0, length))
       writestring(result, offset + 1, data)
       return result, offset + 1 + length, size
     elseif length <= 0xFF then
-      if offset + 2 + length > size then
-        result, size = inflate(result, offset + 2 + length, size)
-      end
+      result, size = inflate(result, offset + 2 + length, size)
 
       writeu8(result, offset, 0xD9)
       writeu8(result, offset + 1, length)
       writestring(result, offset + 2, data)
       return result, offset + 2 + length, size
     elseif length <= 0xFFFF then
-      if offset + 3 + length > size then
-        result, size = inflate(result, offset + 3 + length, size)
-      end
+      result, size = inflate(result, offset + 3 + length, size)
 
       writeu8(result, offset, 0xDA)
       writeu16(result, offset + 1, length)
       writestring(result, offset + 3, data)
       return result, offset + 3 + length, size
     elseif length <= 0xFFFFFFFF then
-      if offset + 5 + length > size then
-        result, size = inflate(result, offset + 5 + length, size)
-      end
+      result, size = inflate(result, offset + 5 + length, size)
 
       writeu8(result, offset, 0xDB)
       writeu32(result, offset + 1, length)
@@ -445,27 +439,21 @@ local function encode(
     local length = bufferLen(data)
 
     if length <= 0xFF then
-      if offset + 2 + length > size then
-        result, size = inflate(result, offset + 2 + length, size)
-      end
+      result, size = inflate(result, offset + 2 + length, size)
 
       writeu8(result, offset, 0xC4)
       writeu8(result, offset + 1, length)
       bufferCopy(result, offset + 2, data)
       return result, offset + 2 + length, size
     elseif length <= 0xFFFF then
-      if offset + 3 + length > size then
-        result, size = inflate(result, offset + 3 + length, size)
-      end
+      result, size = inflate(result, offset + 3 + length, size)
 
       writeu8(result, offset, 0xC5)
       writeu16(result, offset + 1, length)
       bufferCopy(result, offset + 3, data)
       return result, offset + 3 + length, size
     elseif length <= 0xFFFFFFFF then
-      if offset + 5 + length > size then
-        result, size = inflate(result, offset + 5 + length, size)
-      end
+      result, size = inflate(result, offset + 5 + length, size)
 
       writeu8(result, offset, 0xC6)
       writeu32(result, offset + 1, length)
@@ -478,30 +466,22 @@ local function encode(
   elseif dtype == "number" then
     -- represents NaN, Inf, -Inf as float 32 to save space
     if data == 0 then
-      if offset + 1 > size then
-        result, size = inflate(result, offset + 1, size)
-      end
+      result, size = inflate(result, offset + 1, size)
 
       writeu8(result, offset, 0)
       return result, offset + 1, size
     elseif data ~= data then -- NaN
-      if offset + 5 > size then
-        result, size = inflate(result, offset + 5, size)
-      end
+      result, size = inflate(result, offset + 5, size)
 
       writestring(result, offset, "\xCA\x7F\x80\x00\x01")
       return result, offset + 5, size
     elseif data == math.huge then
-      if offset + 5 > size then
-        result, size = inflate(result, offset + 5, size)
-      end
+      result, size = inflate(result, offset + 5, size)
 
       writestring(result, offset, "\xCA\x7F\x80\x00\x00")
       return result, offset + 5, size
     elseif data == -math.huge then
-      if offset + 5 > size then
-        result, size = inflate(result, offset + 5, size)
-      end
+      result, size = inflate(result, offset + 5, size)
 
       writestring(result, offset, "\xCA\xFF\x80\x00\x00")
       return result, offset + 5, size
@@ -511,9 +491,7 @@ local function encode(
     local sign = sign(data)
 
     if fractional ~= 0 or integral > 0xFFFFFFFF or integral < -0x80000000 then
-      if offset + 9 > size then
-        result, size = inflate(result, offset + 9, size)
-      end
+      result, size = inflate(result, offset + 9, size)
 
       -- float 64
       writeu8(result, offset, 0xCB)
@@ -523,32 +501,24 @@ local function encode(
 
     if sign > 0 then
       if integral <= 127 then -- positive fixint
-        if offset + 1 > size then
-          result, size = inflate(result, offset + 1, size)
-        end
+        result, size = inflate(result, offset + 1, size)
 
         writeu8(result, offset, integral)
         return result, offset + 1, size
       elseif integral <= 0xFF then -- uint 8
-        if offset + 2 > size then
-          result, size = inflate(result, offset + 2, size)
-        end
+        result, size = inflate(result, offset + 2, size)
 
         writeu8(result, offset, 0xCC)
         writeu8(result, offset + 1, integral)
         return result, offset + 2, size
       elseif integral <= 0xFFFF then -- uint 16
-        if offset + 3 > size then
-          result, size = inflate(result, offset + 3, size)
-        end
+        result, size = inflate(result, offset + 3, size)
 
         writeu8(result, offset, 0xCD)
         writeu16(result, offset + 1, integral)
         return result, offset + 3, size
       elseif integral <= 0xFFFFFFFF then -- uint 32
-        if offset + 5 > size then
-          result, size = inflate(result, offset + 5, size)
-        end
+        result, size = inflate(result, offset + 5, size)
 
         writeu8(result, offset, 0xCE)
         writeu32(result, offset + 1, integral)
@@ -556,32 +526,24 @@ local function encode(
       end
     else
       if integral >= -0x20 then -- negative fixint
-        if offset + 1 > size then
-          result, size = inflate(result, offset + 1, size)
-        end
+        result, size = inflate(result, offset + 1, size)
 
         writeu8(result, offset, bor(0xE0, extract(integral, 0, 5)))
         return result, offset + 1, size
       elseif integral >= -0x80 then -- int 8
-        if offset + 2 > size then
-          result, size = inflate(result, offset + 2, size)
-        end
+        result, size = inflate(result, offset + 2, size)
 
         writeu8(result, offset, 0xD0)
         writei8(result, offset + 1, integral)
         return result, offset + 2, size
       elseif integral >= -0x8000 then -- int 16
-        if offset + 3 > size then
-          result, size = inflate(result, offset + 3, size)
-        end
+        result, size = inflate(result, offset + 3, size)
 
         writeu8(result, offset, 0xD1)
         writei16(result, offset + 1, integral)
         return result, offset + 3, size
       elseif integral >= -0x80000000 then -- int 32
-        if offset + 5 > size then
-          result, size = inflate(result, offset + 5, size)
-        end
+        result, size = inflate(result, offset + 5, size)
 
         writeu8(result, offset, 0xD2)
         writei32(result, offset + 1, integral)
@@ -596,9 +558,7 @@ local function encode(
 
     if msgpackType then
       if msgpackType == msgpack.Int64 or msgpackType == msgpack.UInt64 then
-        if offset + 9 > size then
-          result, size = inflate(result, offset + 9, size)
-        end
+        result, size = inflate(result, offset + 9, size)
 
         local intType = if msgpackType == msgpack.UInt64 then 0xCF else 0xD3
         writeu8(result, offset, intType)
@@ -610,9 +570,7 @@ local function encode(
         local extType = extensionTypeLUT[length]
 
         if extType then
-          if offset + 2 + length > size then
-            result, size = inflate(result, offset + 2 + length, size)
-          end
+          result, size = inflate(result, offset + 2 + length, size)
 
           writeu8(result, offset, extType)
           writeu8(result, offset + 1, data.type)
@@ -621,9 +579,7 @@ local function encode(
         end
 
         if length <= 0xFF then
-          if offset + 3 + length > size then
-            result, size = inflate(result, offset + 3 + length, size)
-          end
+          result, size = inflate(result, offset + 3 + length, size)
 
           writeu8(result, offset, 0xC7)
           writeu8(result, offset + 1, length)
@@ -631,9 +587,7 @@ local function encode(
           bufferCopy(result, offset + 3, data.data)
           return result, offset + 3 + length, size
         elseif length <= 0xFFFF then
-          if offset + 4 + length > size then
-            result, size = inflate(result, offset + 4 + length, size)
-          end
+          result, size = inflate(result, offset + 4 + length, size)
 
           writeu8(result, offset, 0xC8)
           writeu16(result, offset + 1, length)
@@ -641,9 +595,7 @@ local function encode(
           bufferCopy(result, offset + 4, data.data)
           return result, offset + 4 + length, size
         elseif length <= 0xFFFFFFFF then
-          if offset + 6 + length > size then
-            result, size = inflate(result, offset + 6 + length, size)
-          end
+          result, size = inflate(result, offset + 6 + length, size)
 
           writeu8(result, offset, 0xC9)
           writeu32(result, offset + 1, length)
@@ -672,24 +624,18 @@ local function encode(
     if length == mapLength then -- array
       local newOffset = offset
       if length <= 15 then
-        if offset + 1 > size then
-          result, size = inflate(result, offset + 1, size)
-        end
+        result, size = inflate(result, offset + 1, size)
 
         writeu8(result, offset, bor(0x90, mapLength))
         newOffset += 1
       elseif length <= 0xFFFF then
-        if offset + 3 > size then
-          result, size = inflate(result, offset + 3, size)
-        end
+        result, size = inflate(result, offset + 3, size)
 
         writeu8(result, offset, 0xDC)
         writeu16(result, offset + 1, length)
         newOffset += 3
       elseif length <= 0xFFFFFFFF then
-        if offset + 5 > size then
-          result, size = inflate(result, offset + 5, size)
-        end
+        result, size = inflate(result, offset + 5, size)
 
         writeu8(result, offset, 0xDD)
         writeu32(result, offset + 1, length)
@@ -707,24 +653,18 @@ local function encode(
     else -- map
       local newOffset = offset
       if mapLength <= 15 then
-        if offset + 1 > size then
-          result, size = inflate(result, offset + 1, size)
-        end
+        result, size = inflate(result, offset + 1, size)
 
         writeu8(result, offset, bor(0x80, mapLength))
         newOffset += 1
       elseif mapLength <= 0xFFFF then
-        if offset + 3 > size then
-          result, size = inflate(result, offset + 3, size)
-        end
+        result, size = inflate(result, offset + 3, size)
 
         writeu8(result, offset, 0xDE)
         writeu16(result, offset + 1, mapLength)
         newOffset += 3
       elseif mapLength <= 0xFFFFFFFF then
-        if offset + 5 > size then
-          result, size = inflate(result, offset + 5, size)
-        end
+        result, size = inflate(result, offset + 5, size)
 
         writeu8(result, offset, 0xDF)
         writeu32(result, offset + 1, mapLength)

--- a/src/msgpack.lua
+++ b/src/msgpack.lua
@@ -347,23 +347,20 @@ local function parse(message: buffer, offset: number): (any, number)
   error("Not all decoder cases are handled, report as bug to msgpack-luau maintainer")
 end
 
-local function inflateInternal(result: buffer, minSize: number, oldSize: number)
-
-  while minSize > oldSize do
-    oldSize *= 2
-  end
-
-  local temp = bufferCreate(oldSize)
-  bufferCopy(temp, 0, result)
-  return temp, oldSize
+local function inflateSlow(result: buffer, size: number)
+	local newBuffer = bufferCreate(size)
+	bufferCopy(newBuffer, 0, result)
+	return newBuffer
 end
 
-local function inflate(result: buffer, minSize: number, oldSize: number)
-  if minSize > oldSize then
-    local newResult, newSize = inflateInternal(result, minSize, oldSize)
-    return newResult, newSize
-  end
-  return result, oldSize
+local function inflate(result: buffer, cursor: number, len: number)
+	local bits = bit32.countlz(cursor + len)
+	if bits == bit32.countlz(cursor) then
+		return result
+	end
+
+	local size = 2 ^ (32 - bits)
+	return inflateSlow(result, size)
 end
 
 local extensionTypeLUT = {
@@ -377,57 +374,56 @@ local extensionTypeLUT = {
 local function encode(
   result: buffer,
   offset: number,
-  size: number,
   data: any,
   tableSet: { [any]: boolean }
-): (buffer, number, number)
+): (buffer, number)
 
   local dtype = type(data)
   if data == nil then
-    result, size = inflate(result, offset + 1, size)
+    result = inflate(result, offset, 1)
 
     writestring(result, offset, "\xC0")
-    return result, offset + 1, size
+    return result, offset + 1
   elseif data == false then
-    result, size = inflate(result, offset + 1, size)
+    result = inflate(result, offset, 1)
 
     writestring(result, offset, "\xC2")
-    return result, offset + 1, size
+    return result, offset + 1
   elseif data == true then
-    result, size = inflate(result, offset + 1, size)
+    result = inflate(result, offset, 1)
 
     writestring(result, offset, "\xC3")
-    return result, offset + 1, size
+    return result, offset + 1
   elseif dtype == "string" then
     local length = #data
 
     if length <= 31 then
-      result, size = inflate(result, offset + 1 + length, size)
+      result = inflate(result, offset,  1 + length)
 
       writeu8(result, offset, bor(0xA0, length))
       writestring(result, offset + 1, data)
-      return result, offset + 1 + length, size
+      return result, offset + 1 + length
     elseif length <= 0xFF then
-      result, size = inflate(result, offset + 2 + length, size)
+      result = inflate(result, offset, 2 + length)
 
       writeu8(result, offset, 0xD9)
       writeu8(result, offset + 1, length)
       writestring(result, offset + 2, data)
-      return result, offset + 2 + length, size
+      return result, offset + 2 + length
     elseif length <= 0xFFFF then
-      result, size = inflate(result, offset + 3 + length, size)
+      result = inflate(result, offset, 3 + length)
 
       writeu8(result, offset, 0xDA)
       writeu16(result, offset + 1, length)
       writestring(result, offset + 3, data)
-      return result, offset + 3 + length, size
+      return result, offset + 3 + length
     elseif length <= 0xFFFFFFFF then
-      result, size = inflate(result, offset + 5 + length, size)
+      result = inflate(result, offset, 5 + length)
 
       writeu8(result, offset, 0xDB)
       writeu32(result, offset + 1, length)
       writestring(result, offset + 5, data)
-      return result, offset + 5 + length, size
+      return result, offset + 5 + length
     end
 
     error("Could not encode - too long string")
@@ -436,26 +432,26 @@ local function encode(
     local length = bufferLen(data)
 
     if length <= 0xFF then
-      result, size = inflate(result, offset + 2 + length, size)
+      result = inflate(result, offset, 2 + length)
 
       writeu8(result, offset, 0xC4)
       writeu8(result, offset + 1, length)
       bufferCopy(result, offset + 2, data)
-      return result, offset + 2 + length, size
+      return result, offset + 2 + length
     elseif length <= 0xFFFF then
-      result, size = inflate(result, offset + 3 + length, size)
+      result = inflate(result, offset, 3 + length)
 
       writeu8(result, offset, 0xC5)
       writeu16(result, offset + 1, length)
       bufferCopy(result, offset + 3, data)
-      return result, offset + 3 + length, size
+      return result, offset + 3 + length
     elseif length <= 0xFFFFFFFF then
-      result, size = inflate(result, offset + 5 + length, size)
+      result = inflate(result, offset, 5 + length)
 
       writeu8(result, offset, 0xC6)
       writeu32(result, offset + 1, length)
       bufferCopy(result, offset + 5, data)
-      return result, offset + 5 + length, size
+      return result, offset + 5 + length
     end
 
     error("Could not encode - too long binary buffer")
@@ -463,88 +459,88 @@ local function encode(
   elseif dtype == "number" then
     -- represents NaN, Inf, -Inf as float 32 to save space
     if data == 0 then
-      result, size = inflate(result, offset + 1, size)
+      result = inflate(result, offset, 1)
 
       writeu8(result, offset, 0)
-      return result, offset + 1, size
+      return result, offset + 1
     elseif data ~= data then -- NaN
-      result, size = inflate(result, offset + 5, size)
+      result = inflate(result, offset, 5)
 
       writestring(result, offset, "\xCA\x7F\x80\x00\x01")
-      return result, offset + 5, size
+      return result, offset + 5
     elseif data == math.huge then
-      result, size = inflate(result, offset + 5, size)
+      result = inflate(result, offset, 5)
 
       writestring(result, offset, "\xCA\x7F\x80\x00\x00")
-      return result, offset + 5, size
+      return result, offset + 5
     elseif data == -math.huge then
-      result, size = inflate(result, offset + 5, size)
+      result = inflate(result, offset, 5)
 
       writestring(result, offset, "\xCA\xFF\x80\x00\x00")
-      return result, offset + 5, size
+      return result, offset + 5
     end
 
     local integral, fractional = modf(data)
     local sign = sign(data)
 
     if fractional ~= 0 or integral > 0xFFFFFFFF or integral < -0x80000000 then
-      result, size = inflate(result, offset + 9, size)
+      result = inflate(result, offset, 9)
 
       -- float 64
       writeu8(result, offset, 0xCB)
       writef64(result, offset + 1, data)
-      return result, offset + 9, size
+      return result, offset + 9
     end
 
     if sign > 0 then
       if integral <= 127 then -- positive fixint
-        result, size = inflate(result, offset + 1, size)
+        result = inflate(result, offset, 1)
 
         writeu8(result, offset, integral)
-        return result, offset + 1, size
+        return result, offset + 1
       elseif integral <= 0xFF then -- uint 8
-        result, size = inflate(result, offset + 2, size)
+        result = inflate(result, offset, 2)
 
         writeu8(result, offset, 0xCC)
         writeu8(result, offset + 1, integral)
-        return result, offset + 2, size
+        return result, offset + 2
       elseif integral <= 0xFFFF then -- uint 16
-        result, size = inflate(result, offset + 3, size)
+        result = inflate(result, offset, 3)
 
         writeu8(result, offset, 0xCD)
         writeu16(result, offset + 1, integral)
-        return result, offset + 3, size
+        return result, offset + 3
       elseif integral <= 0xFFFFFFFF then -- uint 32
-        result, size = inflate(result, offset + 5, size)
+        result = inflate(result, offset, 5)
 
         writeu8(result, offset, 0xCE)
         writeu32(result, offset + 1, integral)
-        return result, offset + 5, size
+        return result, offset + 5
       end
     else
       if integral >= -0x20 then -- negative fixint
-        result, size = inflate(result, offset + 1, size)
+        result = inflate(result, offset, 1)
 
         writeu8(result, offset, bor(0xE0, extract(integral, 0, 5)))
-        return result, offset + 1, size
+        return result, offset + 1
       elseif integral >= -0x80 then -- int 8
-        result, size = inflate(result, offset + 2, size)
+        result = inflate(result, offset, 2)
 
         writeu8(result, offset, 0xD0)
         writei8(result, offset + 1, integral)
-        return result, offset + 2, size
+        return result, offset + 2
       elseif integral >= -0x8000 then -- int 16
-        result, size = inflate(result, offset + 3, size)
+        result = inflate(result, offset, 3)
 
         writeu8(result, offset, 0xD1)
         writei16(result, offset + 1, integral)
-        return result, offset + 3, size
+        return result, offset + 3
       elseif integral >= -0x80000000 then -- int 32
-        result, size = inflate(result, offset + 5, size)
+        result = inflate(result, offset, 5)
 
         writeu8(result, offset, 0xD2)
         writei32(result, offset + 1, integral)
-        return result, offset + 5, size
+        return result, offset + 5
       end
     end
 
@@ -555,50 +551,50 @@ local function encode(
 
     if msgpackType then
       if msgpackType == msgpack.Int64 or msgpackType == msgpack.UInt64 then
-        result, size = inflate(result, offset + 9, size)
+        result = inflate(result, offset, 9)
 
         local intType = if msgpackType == msgpack.UInt64 then 0xCF else 0xD3
         writeu8(result, offset, intType)
         writeu32(result, offset + 1, data.mostSignificantPart)
         writeu32(result, offset + 5, data.leastSignificantPart)
-        return result, offset + 9, size
+        return result, offset + 9
       elseif msgpackType == msgpack.Extension then
         local length = bufferLen(data.data)
         local extType = extensionTypeLUT[length]
 
         if extType then
-          result, size = inflate(result, offset + 2 + length, size)
+          result = inflate(result, offset, 2 + length)
 
           writeu8(result, offset, extType)
           writeu8(result, offset + 1, data.type)
           bufferCopy(result, offset + 2, data.data)
-          return result, offset + 2 + length, size
+          return result, offset + 2 + length
         end
 
         if length <= 0xFF then
-          result, size = inflate(result, offset + 3 + length, size)
+          result = inflate(result, offset, 3 + length)
 
           writeu8(result, offset, 0xC7)
           writeu8(result, offset + 1, length)
           writeu8(result, offset + 2, data.type)
           bufferCopy(result, offset + 3, data.data)
-          return result, offset + 3 + length, size
+          return result, offset + 3 + length
         elseif length <= 0xFFFF then
-          result, size = inflate(result, offset + 4 + length, size)
+          result = inflate(result, offset, 4 + length)
 
           writeu8(result, offset, 0xC8)
           writeu16(result, offset + 1, length)
           writeu8(result, offset + 3, data.type)
           bufferCopy(result, offset + 4, data.data)
-          return result, offset + 4 + length, size
+          return result, offset + 4 + length
         elseif length <= 0xFFFFFFFF then
-          result, size = inflate(result, offset + 6 + length, size)
+          result = inflate(result, offset, 6 + length)
 
           writeu8(result, offset, 0xC9)
           writeu32(result, offset + 1, length)
           writeu8(result, offset + 5, data.type)
           bufferCopy(result, offset + 6, data.data)
-          return result, offset + 6 + length, size
+          return result, offset + 6 + length
         end
 
         error("Could not encode - too long extension data")
@@ -621,18 +617,18 @@ local function encode(
     if length == mapLength then -- array
       local newOffset = offset
       if length <= 15 then
-        result, size = inflate(result, offset + 1, size)
+        result = inflate(result, offset, 1)
 
         writeu8(result, offset, bor(0x90, mapLength))
         newOffset += 1
       elseif length <= 0xFFFF then
-        result, size = inflate(result, offset + 3, size)
+        result = inflate(result, offset, 3)
 
         writeu8(result, offset, 0xDC)
         writeu16(result, offset + 1, length)
         newOffset += 3
       elseif length <= 0xFFFFFFFF then
-        result, size = inflate(result, offset + 5, size)
+        result = inflate(result, offset, 5)
 
         writeu8(result, offset, 0xDD)
         writeu32(result, offset + 1, length)
@@ -642,26 +638,26 @@ local function encode(
       end
 
       for _,v in ipairs(data) do
-        result, newOffset, size = encode(result, newOffset, size, v, tableSet)
+        result, newOffset = encode(result, newOffset, v, tableSet)
       end
 
-      return result, newOffset, size
+      return result, newOffset
 
     else -- map
       local newOffset = offset
       if mapLength <= 15 then
-        result, size = inflate(result, offset + 1, size)
+        result = inflate(result, offset, 1)
 
         writeu8(result, offset, bor(0x80, mapLength))
         newOffset += 1
       elseif mapLength <= 0xFFFF then
-        result, size = inflate(result, offset + 3, size)
+        result = inflate(result, offset, 3)
 
         writeu8(result, offset, 0xDE)
         writeu16(result, offset + 1, mapLength)
         newOffset += 3
       elseif mapLength <= 0xFFFFFFFF then
-        result, size = inflate(result, offset + 5, size)
+        result = inflate(result, offset, 5)
 
         writeu8(result, offset, 0xDF)
         writeu32(result, offset + 1, mapLength)
@@ -671,11 +667,11 @@ local function encode(
       end
 
       for k,v in pairs(data) do
-        result, newOffset, size = encode(result, newOffset, size, k, tableSet)
-        result, newOffset, size = encode(result, newOffset, size, v, tableSet)
+        result, newOffset = encode(result, newOffset, k, tableSet)
+        result, newOffset = encode(result, newOffset, v, tableSet)
       end
 
-      return result, newOffset, size
+      return result, newOffset
     end
   end
 
@@ -771,7 +767,7 @@ function msgpack.decode(message: string): any
 end
 
 function msgpack.encode(data: any): string
-  local result, offset = encode(bufferCreate(64), 0, 64, data, {})
+  local result, offset = encode(bufferCreate(0), 0, data, {})
   return readstring(result, 0, offset)
 end
 

--- a/src/msgpack.lua
+++ b/src/msgpack.lua
@@ -348,9 +348,6 @@ local function parse(message: buffer, offset: number): (any, number)
 end
 
 local function inflateInternal(result: buffer, minSize: number, oldSize: number)
-  if oldSize == 0 then
-    return bufferCreate(minSize), minSize
-  end
 
   while minSize > oldSize do
     oldSize *= 2

--- a/src/msgpack.lua
+++ b/src/msgpack.lua
@@ -347,23 +347,96 @@ local function parse(message: buffer, offset: number): (any, number)
   error("Not all decoder cases are handled, report as bug to msgpack-luau maintainer")
 end
 
-local function computeLength(data: any, tableSet: {[any]: boolean}): number
+local function inflate(result: buffer, minSize: number, oldSize: number)
+  if oldSize == 0 then
+    return bufferCreate(minSize), minSize
+  end
+
+  while minSize > oldSize do
+    oldSize *= 2
+  end
+
+  local temp = bufferCreate(oldSize)
+  bufferCopy(temp, 0, result)
+  return temp, oldSize
+end
+
+local extensionTypeLUT = {
+  [1] = 0xD4,
+  [2] = 0xD5,
+  [4] = 0xD6,
+  [8] = 0xD7,
+  [16] = 0xD8,
+}
+
+local function encode(
+  result: buffer,
+  offset: number,
+  size: number,
+  data: any,
+  tableSet: { [any]: boolean }
+): (buffer, number, number)
+
   local dtype = type(data)
   if data == nil then
-    return 1
-  elseif dtype == "boolean" then
-    return 1
+    if offset + 1 > size then
+      result, size = inflate(result, offset + 1, size)
+    end
+
+    writestring(result, offset, "\xC0")
+    return result, offset + 1, size
+  elseif data == false then
+    if offset + 1 > size then
+      result, size = inflate(result, offset + 1, size)
+    end
+
+    writestring(result, offset, "\xC2")
+    return result, offset + 1, size
+  elseif data == true then
+    if offset + 1 > size then
+      result, size = inflate(result, offset + 1, size)
+    end
+
+    writestring(result, offset, "\xC3")
+    return result, offset + 1, size
   elseif dtype == "string" then
     local length = #data
 
     if length <= 31 then
-      return 1 + length
+      if offset + 1 + length > size then
+        result, size = inflate(result, offset + 1 + length, size)
+      end
+
+      writeu8(result, offset, bor(0xA0, length))
+      writestring(result, offset + 1, data)
+      return result, offset + 1 + length, size
     elseif length <= 0xFF then
-      return 2 + length
+      if offset + 2 + length > size then
+        result, size = inflate(result, offset + 2 + length, size)
+      end
+
+      writeu8(result, offset, 0xD9)
+      writeu8(result, offset + 1, length)
+      writestring(result, offset + 2, data)
+      return result, offset + 2 + length, size
     elseif length <= 0xFFFF then
-      return 3 + length
+      if offset + 3 + length > size then
+        result, size = inflate(result, offset + 3 + length, size)
+      end
+
+      writeu8(result, offset, 0xDA)
+      writeu16(result, offset + 1, length)
+      writestring(result, offset + 3, data)
+      return result, offset + 3 + length, size
     elseif length <= 0xFFFFFFFF then
-      return 5 + length
+      if offset + 5 + length > size then
+        result, size = inflate(result, offset + 5 + length, size)
+      end
+
+      writeu8(result, offset, 0xDB)
+      writeu32(result, offset + 1, length)
+      writestring(result, offset + 5, data)
+      return result, offset + 5 + length, size
     end
 
     error("Could not encode - too long string")
@@ -372,11 +445,32 @@ local function computeLength(data: any, tableSet: {[any]: boolean}): number
     local length = bufferLen(data)
 
     if length <= 0xFF then
-      return 2 + length
+      if offset + 2 + length > size then
+        result, size = inflate(result, offset + 2 + length, size)
+      end
+
+      writeu8(result, offset, 0xC4)
+      writeu8(result, offset + 1, length)
+      bufferCopy(result, offset + 2, data)
+      return result, offset + 2 + length, size
     elseif length <= 0xFFFF then
-      return 3 + length
+      if offset + 3 + length > size then
+        result, size = inflate(result, offset + 3 + length, size)
+      end
+
+      writeu8(result, offset, 0xC5)
+      writeu16(result, offset + 1, length)
+      bufferCopy(result, offset + 3, data)
+      return result, offset + 3 + length, size
     elseif length <= 0xFFFFFFFF then
-      return 5 + length
+      if offset + 5 + length > size then
+        result, size = inflate(result, offset + 5 + length, size)
+      end
+
+      writeu8(result, offset, 0xC6)
+      writeu32(result, offset + 1, length)
+      bufferCopy(result, offset + 5, data)
+      return result, offset + 5 + length, size
     end
 
     error("Could not encode - too long binary buffer")
@@ -384,42 +478,114 @@ local function computeLength(data: any, tableSet: {[any]: boolean}): number
   elseif dtype == "number" then
     -- represents NaN, Inf, -Inf as float 32 to save space
     if data == 0 then
-      return 1
+      if offset + 1 > size then
+        result, size = inflate(result, offset + 1, size)
+      end
+
+      writeu8(result, offset, 0)
+      return result, offset + 1, size
     elseif data ~= data then -- NaN
-      return 5
+      if offset + 5 > size then
+        result, size = inflate(result, offset + 5, size)
+      end
+
+      writestring(result, offset, "\xCA\x7F\x80\x00\x01")
+      return result, offset + 5, size
     elseif data == math.huge then
-      return 5
+      if offset + 5 > size then
+        result, size = inflate(result, offset + 5, size)
+      end
+
+      writestring(result, offset, "\xCA\x7F\x80\x00\x00")
+      return result, offset + 5, size
     elseif data == -math.huge then
-      return 5
+      if offset + 5 > size then
+        result, size = inflate(result, offset + 5, size)
+      end
+
+      writestring(result, offset, "\xCA\xFF\x80\x00\x00")
+      return result, offset + 5, size
     end
 
     local integral, fractional = modf(data)
     local sign = sign(data)
 
     if fractional ~= 0 or integral > 0xFFFFFFFF or integral < -0x80000000 then
+      if offset + 9 > size then
+        result, size = inflate(result, offset + 9, size)
+      end
+
       -- float 64
-      return 9
+      writeu8(result, offset, 0xCB)
+      writef64(result, offset + 1, data)
+      return result, offset + 9, size
     end
 
     if sign > 0 then
       if integral <= 127 then -- positive fixint
-        return 1
+        if offset + 1 > size then
+          result, size = inflate(result, offset + 1, size)
+        end
+
+        writeu8(result, offset, integral)
+        return result, offset + 1, size
       elseif integral <= 0xFF then -- uint 8
-        return 2
+        if offset + 2 > size then
+          result, size = inflate(result, offset + 2, size)
+        end
+
+        writeu8(result, offset, 0xCC)
+        writeu8(result, offset + 1, integral)
+        return result, offset + 2, size
       elseif integral <= 0xFFFF then -- uint 16
-        return 3
+        if offset + 3 > size then
+          result, size = inflate(result, offset + 3, size)
+        end
+
+        writeu8(result, offset, 0xCD)
+        writeu16(result, offset + 1, integral)
+        return result, offset + 3, size
       elseif integral <= 0xFFFFFFFF then -- uint 32
-        return 5
+        if offset + 5 > size then
+          result, size = inflate(result, offset + 5, size)
+        end
+
+        writeu8(result, offset, 0xCE)
+        writeu32(result, offset + 1, integral)
+        return result, offset + 5, size
       end
     else
       if integral >= -0x20 then -- negative fixint
-        return 1
+        if offset + 1 > size then
+          result, size = inflate(result, offset + 1, size)
+        end
+
+        writeu8(result, offset, bor(0xE0, extract(integral, 0, 5)))
+        return result, offset + 1, size
       elseif integral >= -0x80 then -- int 8
-        return 2
+        if offset + 2 > size then
+          result, size = inflate(result, offset + 2, size)
+        end
+
+        writeu8(result, offset, 0xD0)
+        writei8(result, offset + 1, integral)
+        return result, offset + 2, size
       elseif integral >= -0x8000 then -- int 16
-        return 3
+        if offset + 3 > size then
+          result, size = inflate(result, offset + 3, size)
+        end
+
+        writeu8(result, offset, 0xD1)
+        writei16(result, offset + 1, integral)
+        return result, offset + 3, size
       elseif integral >= -0x80000000 then -- int 32
-        return 5
+        if offset + 5 > size then
+          result, size = inflate(result, offset + 5, size)
+        end
+
+        writeu8(result, offset, 0xD2)
+        writei32(result, offset + 1, integral)
+        return result, offset + 5, size
       end
     end
 
@@ -430,26 +596,60 @@ local function computeLength(data: any, tableSet: {[any]: boolean}): number
 
     if msgpackType then
       if msgpackType == msgpack.Int64 or msgpackType == msgpack.UInt64 then
-        return 9
+        if offset + 9 > size then
+          result, size = inflate(result, offset + 9, size)
+        end
+
+        local intType = if msgpackType == msgpack.UInt64 then 0xCF else 0xD3
+        writeu8(result, offset, intType)
+        writeu32(result, offset + 1, data.mostSignificantPart)
+        writeu32(result, offset + 5, data.leastSignificantPart)
+        return result, offset + 9, size
       elseif msgpackType == msgpack.Extension then
         local length = bufferLen(data.data)
+        local extType = extensionTypeLUT[length]
 
-        if length == 1 then
-          return 3
-        elseif length == 2 then
-          return 4
-        elseif length == 4 then
-          return 6
-        elseif length == 8 then
-          return 10
-        elseif length == 16 then
-          return 18
-        elseif length <= 0xFF then
-          return 3 + length
+        if extType then
+          if offset + 2 + length > size then
+            result, size = inflate(result, offset + 2 + length, size)
+          end
+
+          writeu8(result, offset, extType)
+          writeu8(result, offset + 1, data.type)
+          bufferCopy(result, offset + 2, data.data)
+          return result, offset + 2 + length, size
+        end
+
+        if length <= 0xFF then
+          if offset + 3 + length > size then
+            result, size = inflate(result, offset + 3 + length, size)
+          end
+
+          writeu8(result, offset, 0xC7)
+          writeu8(result, offset + 1, length)
+          writeu8(result, offset + 2, data.type)
+          bufferCopy(result, offset + 3, data.data)
+          return result, offset + 3 + length, size
         elseif length <= 0xFFFF then
-          return 4 + length
+          if offset + 4 + length > size then
+            result, size = inflate(result, offset + 4 + length, size)
+          end
+
+          writeu8(result, offset, 0xC8)
+          writeu16(result, offset + 1, length)
+          writeu8(result, offset + 3, data.type)
+          bufferCopy(result, offset + 4, data.data)
+          return result, offset + 4 + length, size
         elseif length <= 0xFFFFFFFF then
-          return 6 + length
+          if offset + 6 + length > size then
+            result, size = inflate(result, offset + 6 + length, size)
+          end
+
+          writeu8(result, offset, 0xC9)
+          writeu32(result, offset + 1, length)
+          writeu8(result, offset + 5, data.type)
+          bufferCopy(result, offset + 6, data.data)
+          return result, offset + 6 + length, size
         end
 
         error("Could not encode - too long extension data")
@@ -469,237 +669,28 @@ local function computeLength(data: any, tableSet: {[any]: boolean}): number
       mapLength += 1
     end
 
-    local headerLen
-    if mapLength <= 15 then
-      headerLen = 1
-    elseif mapLength <= 0xFFFF then
-      headerLen = 3
-    elseif mapLength <= 0xFFFFFFFF then
-      headerLen = 5
-    else
-      if length == mapLength then
-        error("Could not encode - too long array")
-      else
-        error("Could not encode - too long map")
-      end
-    end
-
-    if length == mapLength then -- array
-      local contentLen = 0
-      for _,v in ipairs(data) do
-        contentLen += computeLength(v, tableSet)
-      end
-
-      return headerLen + contentLen
-
-    else -- map
-      local contentLen = 0
-      for k,v in pairs(data) do
-        contentLen += computeLength(k, tableSet)
-        contentLen += computeLength(v, tableSet)
-      end
-
-      return headerLen + contentLen
-    end
-  end
-
-  error(string.format("Could not encode - unsupported datatype \"%s\"", typeof(data)))
-end
-
-local extensionTypeLUT = {
-  [1] = 0xD4,
-  [2] = 0xD5,
-  [4] = 0xD6,
-  [8] = 0xD7,
-  [16] = 0xD8,
-}
-
-local function encode(result: buffer, offset: number, data: any): number
-
-  local dtype = type(data)
-  if data == nil then
-    writestring(result, offset, "\xC0")
-    return offset + 1
-  elseif data == false then
-    writestring(result, offset, "\xC2")
-    return offset + 1
-  elseif data == true then
-    writestring(result, offset, "\xC3")
-    return offset + 1
-  elseif dtype == "string" then
-    local length = #data
-
-    if length <= 31 then
-      writeu8(result, offset, bor(0xA0, length))
-      writestring(result, offset + 1, data)
-      return offset + 1 + length
-    elseif length <= 0xFF then
-      writeu8(result, offset, 0xD9)
-      writeu8(result, offset + 1, length)
-      writestring(result, offset + 2, data)
-      return offset + 2 + length
-    elseif length <= 0xFFFF then
-      writeu8(result, offset, 0xDA)
-      writeu16(result, offset + 1, length)
-      writestring(result, offset + 3, data)
-      return offset + 3 + length
-    elseif length <= 0xFFFFFFFF then
-      writeu8(result, offset, 0xDB)
-      writeu32(result, offset + 1, length)
-      writestring(result, offset + 5, data)
-      return offset + 5 + length
-    end
-
-    error("Could not encode - too long string")
-
-  elseif dtype == "buffer" then
-    local length = bufferLen(data)
-
-    if length <= 0xFF then
-      writeu8(result, offset, 0xC4)
-      writeu8(result, offset + 1, length)
-      bufferCopy(result, offset + 2, data)
-      return offset + 2 + length
-    elseif length <= 0xFFFF then
-      writeu8(result, offset, 0xC5)
-      writeu16(result, offset + 1, length)
-      bufferCopy(result, offset + 3, data)
-      return offset + 3 + length
-    elseif length <= 0xFFFFFFFF then
-      writeu8(result, offset, 0xC6)
-      writeu32(result, offset + 1, length)
-      bufferCopy(result, offset + 5, data)
-      return offset + 5 + length
-    end
-
-    error("Could not encode - too long binary buffer")
-
-  elseif dtype == "number" then
-    -- represents NaN, Inf, -Inf as float 32 to save space
-    if data == 0 then
-      writeu8(result, offset, 0)
-      return offset + 1
-    elseif data ~= data then -- NaN
-      writestring(result, offset, "\xCA\x7F\x80\x00\x01")
-      return offset + 5
-    elseif data == math.huge then
-      writestring(result, offset, "\xCA\x7F\x80\x00\x00")
-      return offset + 5
-    elseif data == -math.huge then
-      writestring(result, offset, "\xCA\xFF\x80\x00\x00")
-      return offset + 5
-    end
-
-    local integral, fractional = modf(data)
-    local sign = sign(data)
-
-    if fractional ~= 0 or integral > 0xFFFFFFFF or integral < -0x80000000 then
-      -- float 64
-      writeu8(result, offset, 0xCB)
-      writef64(result, offset + 1, data)
-      return offset + 9
-    end
-
-    if sign > 0 then
-      if integral <= 127 then -- positive fixint
-        writeu8(result, offset, integral)
-        return offset + 1
-      elseif integral <= 0xFF then -- uint 8
-        writeu8(result, offset, 0xCC)
-        writeu8(result, offset + 1, integral)
-        return offset + 2
-      elseif integral <= 0xFFFF then -- uint 16
-        writeu8(result, offset, 0xCD)
-        writeu16(result, offset + 1, integral)
-        return offset + 3
-      elseif integral <= 0xFFFFFFFF then -- uint 32
-        writeu8(result, offset, 0xCE)
-        writeu32(result, offset + 1, integral)
-        return offset + 5
-      end
-    else
-      if integral >= -0x20 then -- negative fixint
-        writeu8(result, offset, bor(0xE0, extract(integral, 0, 5)))
-        return offset + 1
-      elseif integral >= -0x80 then -- int 8
-        writeu8(result, offset, 0xD0)
-        writei8(result, offset + 1, integral)
-        return offset + 2
-      elseif integral >= -0x8000 then -- int 16
-        writeu8(result, offset, 0xD1)
-        writei16(result, offset + 1, integral)
-        return offset + 3
-      elseif integral >= -0x80000000 then -- int 32
-        writeu8(result, offset, 0xD2)
-        writei32(result, offset + 1, integral)
-        return offset + 5
-      end
-    end
-
-    error(string.format("Could not encode - unhandled number \"%s\"", typeof(data)))
-
-  elseif dtype == "table" then
-    local msgpackType = data._msgpackType
-
-    if msgpackType then
-      if msgpackType == msgpack.Int64 or msgpackType == msgpack.UInt64 then
-        local intType = if msgpackType == msgpack.UInt64 then 0xCF else 0xD3
-        writeu8(result, offset, intType)
-        writeu32(result, offset + 1, data.mostSignificantPart)
-        writeu32(result, offset + 5, data.leastSignificantPart)
-        return offset + 9
-      elseif msgpackType == msgpack.Extension then
-        local length = bufferLen(data.data)
-        local extType = extensionTypeLUT[length]
-
-        if extType then
-          writeu8(result, offset, extType)
-          writeu8(result, offset + 1, data.type)
-          bufferCopy(result, offset + 2, data.data)
-          return offset + 2 + length
-        end
-
-        if length <= 0xFF then
-          writeu8(result, offset, 0xC7)
-          writeu8(result, offset + 1, length)
-          writeu8(result, offset + 2, data.type)
-          bufferCopy(result, offset + 3, data.data)
-          return offset + 3 + length
-        elseif length <= 0xFFFF then
-          writeu8(result, offset, 0xC8)
-          writeu16(result, offset + 1, length)
-          writeu8(result, offset + 3, data.type)
-          bufferCopy(result, offset + 4, data.data)
-          return offset + 4 + length
-        elseif length <= 0xFFFFFFFF then
-          writeu8(result, offset, 0xC9)
-          writeu32(result, offset + 1, length)
-          writeu8(result, offset + 5, data.type)
-          bufferCopy(result, offset + 6, data.data)
-          return offset + 6 + length
-        end
-
-        error("Could not encode - too long extension data")
-      end
-    end
-
-    local length = #data
-    local mapLength = 0
-
-    for _,_ in pairs(data) do
-      mapLength += 1
-    end
-
     if length == mapLength then -- array
       local newOffset = offset
       if length <= 15 then
+        if offset + 1 > size then
+          result, size = inflate(result, offset + 1, size)
+        end
+
         writeu8(result, offset, bor(0x90, mapLength))
         newOffset += 1
       elseif length <= 0xFFFF then
+        if offset + 3 > size then
+          result, size = inflate(result, offset + 3, size)
+        end
+
         writeu8(result, offset, 0xDC)
         writeu16(result, offset + 1, length)
         newOffset += 3
       elseif length <= 0xFFFFFFFF then
+        if offset + 5 > size then
+          result, size = inflate(result, offset + 5, size)
+        end
+
         writeu8(result, offset, 0xDD)
         writeu32(result, offset + 1, length)
         newOffset += 5
@@ -708,21 +699,33 @@ local function encode(result: buffer, offset: number, data: any): number
       end
 
       for _,v in ipairs(data) do
-        newOffset = encode(result, newOffset, v)
+        result, newOffset, size = encode(result, newOffset, size, v, tableSet)
       end
 
-      return newOffset
+      return result, newOffset, size
 
     else -- map
       local newOffset = offset
       if mapLength <= 15 then
+        if offset + 1 > size then
+          result, size = inflate(result, offset + 1, size)
+        end
+
         writeu8(result, offset, bor(0x80, mapLength))
         newOffset += 1
       elseif mapLength <= 0xFFFF then
+        if offset + 3 > size then
+          result, size = inflate(result, offset + 3, size)
+        end
+
         writeu8(result, offset, 0xDE)
         writeu16(result, offset + 1, mapLength)
         newOffset += 3
       elseif mapLength <= 0xFFFFFFFF then
+        if offset + 5 > size then
+          result, size = inflate(result, offset + 5, size)
+        end
+
         writeu8(result, offset, 0xDF)
         writeu32(result, offset + 1, mapLength)
         newOffset += 5
@@ -731,11 +734,11 @@ local function encode(result: buffer, offset: number, data: any): number
       end
 
       for k,v in pairs(data) do
-        newOffset = encode(result, newOffset, k)
-        newOffset = encode(result, newOffset, v)
+        result, newOffset, size = encode(result, newOffset, size, k, tableSet)
+        result, newOffset, size = encode(result, newOffset, size, v, tableSet)
       end
 
-      return newOffset
+      return result, newOffset, size
     end
   end
 
@@ -831,10 +834,8 @@ function msgpack.decode(message: string): any
 end
 
 function msgpack.encode(data: any): string
-  local length = computeLength(data, {})
-  local result = bufferCreate(length)
-  encode(result, 0, data)
-  return buffer.tostring(result)
+  local result, offset = encode(bufferCreate(64), 0, 64, data, {})
+  return readstring(result, 0, offset)
 end
 
 export type Int64     = { _msgpackType: typeof(msgpack.Int64), mostSignificantPart: number, leastSignificantPart: number }


### PR DESCRIPTION
Inflate lazily doubles the buffer's size on demand instead of calculating the length of the buffer immediately.  

The initial buffer size and multiplier of the buffer size can be honed further.  I do not have enough datasets to gauge the optimal values.

I initialized the buffer size to 64 since I expect most MessagePack users encode tables and not individual values.

**Reasoning:**
`computeLength` needs to do redundant work.  It needs to obtain the data's type and to check the table's size, both moderately expensive.

`inflate` removes the aforementioned redundancy, albeit at a cost since there is less information about the data when encoding. 

**Pros:**
- 29% faster in the provided case, but some other cases are 15-20% faster

**Cons:**
- 134% more memory used in the provided case, but some other cases are 150-200% more memory used
- Code is less readable
- Performance is less stable for the provided case, and some cases will become slower.

**Future Work:**
- Should this PR get accepted, look into improving the readability and performance further.
- Should this PR get rejected, look into harnessing the knowledge from computeLength to improve performance when encoding.  If possible.
  - I do not expect fruitful results, but passing the table size has potential.

**Benchmarks:**
For benchmarking, the following datasets were used:
- [msgpack-default](https://github.com/cipharius/msgpack-luau/blob/main/benchmark/JsonMessage.lua)
- [food-facts](https://world.openfoodfacts.org/api/v0/product/5060292302201.json)
- [pokedex](https://raw.githubusercontent.com/Biuni/PokemonGO-Pokedex/master/pokedex.json)
- [prize](https://api.nobelprize.org/v1/prize.json)
- [others...](https://github.com/jviotti/binary-json-size-benchmark)

If the websites go down containing the datasets, aside from the one provided here, `msgpack-default`, and `others...`, they can be found at [awesome-json-datasets)](https://github.com/jdorfman/awesome-json-datasets).

<details>
<summary>old</summary>

| Dataset Name         | Time (s)           | Space (kB) | Output Size (b) |
|----------------------|--------------------|------------|-----------------|
| benchdata            | 4.374e-3 +- 7.5e-5 | 17 +- 0    | 17020           |
| circleciblank        | 3.099e-6 +- 1.0e-7 | 0 +- 0     | 10              |
| circlecimatrix       | 2.270e-5 +- 5.0e-7 | 1 +- 1     | 72              |
| commitlint           | 1.550e-5 +- 4.0e-7 | 0 +- 1     | 74              |
| commitlintbasic      | 2.699e-6 +- 9.9e-8 | 0 +- 0     | 17              |
| epr                  | 4.360e-5 +- 2.8e-6 | 1 +- 0     | 412             |
| eslintrc             | 7.679e-5 +- 4.6e-6 | 1 +- 1     | 971             |
| esmrc                | 9.799e-6 +- 1.0e-7 | 0 +- 0     | 64              |
| food-facts           | 2.761e-3 +- 5.2e-5 | 49 +- 1    | 34204           |
| geojson              | 7.049e-5 +- 1.2e-5 | 1 +- 0     | 162             |
| githubfundingblank   | 2.999e-6 +- 9.9e-8 | 0 +- 0     | 24              |
| githubworkflow       | 3.340e-5 +- 2.8e-6 | 1 +- 0     | 287             |
| gruntcontribclean    | 1.580e-5 +- 3.1e-6 | 0 +- 1     | 60              |
| imageoptimizerwebjob | 1.190e-5 +- 3.9e-7 | 0 +- 1     | 61              |
| jsonereversesort     | 1.909e-5 +- 1.1e-5 | 0 +- 1     | 52              |
| jsonesort            | 9.200e-6 +- 1.0e-7 | 0 +- 0     | 21              |
| jsonfeed             | 2.280e-5 +- 8.9e-7 | 1 +- 1     | 517             |
| jsonresume           | 1.376e-4 +- 7.2e-6 | 4 +- 1     | 2749            |
| msgpack-default      | 8.072e-4 +- 2.4e-5 | 196 +- 0   | 192245          |
| netcoreproject       | 5.079e-5 +- 5.9e-6 | 1 +- 0     | 919             |
| nightwatch           | 8.679e-5 +- 2.2e-5 | 2 +- 1     | 1037            |
| openweathermap       | 7.300e-5 +- 5.5e-6 | 1 +- 1     | 382             |
| openweatherroadrisk  | 5.829e-5 +- 1.6e-6 | 1 +- 0     | 339             |
| packagejson          | 9.499e-5 +- 5.4e-5 | 2 +- 1     | 1995            |
| packagejsonlintrc    | 7.139e-5 +- 3.6e-6 | 2 +- 1     | 989             |
| pokedex              | 5.350e-3 +- 1.0e-4 | 76 +- 0    | 45094           |
| prize                | 1.251e-2 +- 1.7e-4 | 325 +- 0   | 201437          |
| sapcloudsdkpipeline  | 1.699e-6 +- 1.0e-7 | 0 +- 0     | 1               |
| travisnotifications  | 2.789e-5 +- 1.9e-6 | 1 +- 0     | 627             |
| tslintbasic          | 8.799e-6 +- 3.9e-7 | 0 +- 0     | 51              |
| tslintextend         | 5.000e-6 +- 1.9e-7 | 0 +- 0     | 55              |
| tslintmulti          | 1.440e-5 +- 1.6e-6 | 0 +- 1     | 68              |

</details>

<details>
<summary>new</summary>

| Dataset Name         | Time (s)           | Space (kB) | Output Size (b) |
|----------------------|--------------------|------------|-----------------|
| benchdata            | 3.853e-3 +- 9.4e-5 | 64 +- 1    | 17020           |
| circleciblank        | 2.199e-6 +- 1.0e-7 | 0 +- 0     | 10              |
| circlecimatrix       | 1.790e-5 +- 4.9e-7 | 1 +- 1     | 72              |
| commitlint           | 1.169e-5 +- 2.0e-7 | 0 +- 1     | 74              |
| commitlintbasic      | 1.999e-6 +- 1.0e-7 | 0 +- 0     | 17              |
| epr                  | 3.330e-5 +- 2.3e-6 | 2 +- 1     | 412             |
| eslintrc             | 5.940e-5 +- 1.9e-6 | 2 +- 1     | 971             |
| esmrc                | 7.899e-6 +- 3.8e-6 | 0 +- 0     | 64              |
| food-facts           | 2.218e-3 +- 6.9e-5 | 144 +- 0   | 34204           |
| geojson              | 5.350e-5 +- 1.0e-6 | 2 +- 1     | 162             |
| githubfundingblank   | 2.300e-6 +- 1.0e-7 | 0 +- 0     | 24              |
| githubworkflow       | 2.719e-5 +- 2.2e-6 | 2 +- 1     | 287             |
| gruntcontribclean    | 1.169e-5 +- 4.9e-7 | 0 +- 1     | 60              |
| imageoptimizerwebjob | 8.799e-6 +- 7.0e-7 | 0 +- 1     | 61              |
| jsonereversesort     | 1.379e-5 +- 2.9e-7 | 0 +- 1     | 52              |
| jsonesort            | 5.999e-6 +- 1.0e-7 | 0 +- 0     | 21              |
| jsonfeed             | 2.020e-5 +- 9.9e-7 | 2 +- 0     | 517             |
| jsonresume           | 1.139e-4 +- 7.1e-6 | 9 +- 0     | 2749            |
| msgpack-default      | 7.458e-4 +- 2.7e-4 | 460 +- 1   | 192245          |
| netcoreproject       | 4.339e-5 +- 4.3e-6 | 2 +- 1     | 919             |
| nightwatch           | 7.130e-5 +- 5.9e-6 | 5 +- 1     | 1037            |
| openweathermap       | 5.989e-5 +- 8.7e-6 | 1 +- 1     | 382             |
| openweatherroadrisk  | 4.549e-5 +- 3.3e-6 | 2 +- 1     | 339             |
| packagejson          | 7.789e-5 +- 5.7e-6 | 5 +- 1     | 1995            |
| packagejsonlintrc    | 5.840e-5 +- 5.0e-6 | 3 +- 1     | 989             |
| pokedex              | 4.327e-3 +- 9.3e-5 | 160 +- 0   | 45094           |
| prize                | 9.974e-3 +- 2.2e-4 | 640 +- 0   | 201437          |
| sapcloudsdkpipeline  | 1.200e-6 +- 9.9e-8 | 0 +- 0     | 1               |
| travisnotifications  | 2.440e-5 +- 4.9e-6 | 3 +- 1     | 627             |
| tslintbasic          | 6.700e-6 +- 3.0e-7 | 0 +- 0     | 51              |
| tslintextend         | 3.999e-6 +- 1.9e-7 | 0 +- 0     | 55              |
| tslintmulti          | 1.070e-5 +- 3.9e-7 | 0 +- 1     | 68              |

</details>